### PR TITLE
EL-42 Korrektes Splitten der Textzeilen auch für Windows-Zeilenumbrüche

### DIFF
--- a/src/app/services/parser.service.ts
+++ b/src/app/services/parser.service.ts
@@ -36,7 +36,7 @@ export class ParserService {
      * @return interne Darstellung als {@link EventLog}
      */
     public parse(text: string): EventLog {
-        const lines: string[] = text.split('\n');
+        const lines: string[] = text.split(/\r?\n/);
 
         const indexLog = ParserService.indexOfTokenIfExists(
             lines,


### PR DESCRIPTION
In Windows erstellte Beispiel-Dateien haben als Zeilenumbruch "\r\n", das "\r" ist beim Parsen am Zeilenende verblieben. Das hat nach dem Hochladen einer solchen Datei zu einem Parser-Error geführt, da die Tokens nicht richtig erkannt wurden.