### PR TITLE
EL-54 Bugfix für LogParser (Case IDs wurden bisher nicht übernommen)

### DIFF
--- a/src/app/services/log.service.spec.ts
+++ b/src/app/services/log.service.spec.ts
@@ -17,7 +17,7 @@ describe('Log.ServiceService', () => {
         expect(service).toBeTruthy();
     });
 
-    it('should format internal representation as formatted xes string', () => {
+    it('should format internal representation as formatted log string', () => {
         const sampleExportLog = new EventLog(
             [],
             [],
@@ -47,7 +47,7 @@ describe('Log.ServiceService', () => {
                             'Schwimmen'
                         ),
                     ],
-                    0
+                    7
                 ),
                 new Trace(
                     [],
@@ -64,7 +64,7 @@ describe('Log.ServiceService', () => {
                             'Lesen'
                         ),
                     ],
-                    1
+                    5
                 ),
             ],
             []
@@ -80,10 +80,10 @@ describe('Log.ServiceService', () => {
             'org:role\n' +
             'org:other\n' +
             '.events\n' +
-            "0 Baden 'Group 1' 'Name \\' 1' 'Role 1'\n" +
-            "0 Schwimmen 'Group 2'\n" +
-            "1 Lesen 'Group 3' 'Name 3'\n" +
-            "1 Lesen '' '' '' 'Other Value 4'";
+            "7 Baden 'Group 1' 'Name \\' 1' 'Role 1'\n" +
+            "7 Schwimmen 'Group 2'\n" +
+            "5 Lesen 'Group 3' 'Name 3'\n" +
+            "5 Lesen '' '' '' 'Other Value 4'";
 
         expect(service.generate(sampleExportLog)).toEqual(expectedResult);
     });

--- a/src/app/services/log.service.ts
+++ b/src/app/services/log.service.ts
@@ -70,8 +70,8 @@ export class LogService {
 
         logString += '.events' + '\n';
         logString += traces
-            .map((trace, caseId) =>
-                this.getTraceRepresentation(trace, caseId, attributes)
+            .map(trace =>
+                this.getTraceRepresentation(trace, trace.caseId, attributes)
             )
             .join('\n');
         return logString;


### PR DESCRIPTION
Der Logparser hat bisher nicht die vorhandenen CaseIds der internen Repräsentation übernommen, sondern diese durch neue CaseIds von 0 aufsteigend ersetzt. Das habe ich korrigiert.