### PR TITLE
Exception behoben, Ungleiche Länge ist nie gleich

### DIFF
--- a/src/app/classes/EventLog/eventlog.ts
+++ b/src/app/classes/EventLog/eventlog.ts
@@ -50,6 +50,9 @@ export class EventLog {
         this._traces.forEach(trace => {
             const index = result.findIndex(val => {
                 for (let i = 0; i < val[0].events.length; i++) {
+                    if (val[0].events.length !== trace.events.length) {
+                        return false;
+                    }
                     if (
                         val[0].events[i].activity !== trace.events[i].activity
                     ) {


### PR DESCRIPTION
Wenn man das Beispiel zu_viele_traces.txt im Master parst treten Fehler auf:
"core.mjs:6461 ERROR TypeError: Cannot read properties of undefined (reading 'activity')
    at eventlog.ts:54:71
    at Array.findIndex (<anonymous>)
    at eventlog.ts:51:34
    at Array.forEach (<anonymous>)
    at get sortedTraces [as sortedTraces] (eventlog.ts:50:22)
    at DisplayService.convertEventLogToDiagram (display.service.ts:70:26)
    at DisplayService.displayEventLog (display.service.ts:92:24)
    at AppComponent.processSourceChange (app.component.ts:48:34)
    at app.component.ts:33:36
    at Object.next (Subscriber.js:110:1)"

Behebung indem ungleich lange Traces nicht mehr weiter verglichen werden. Dann greifen wir nichtmehr über das Array hinaus in "undefined" Events.