### PR TITLE
El-49: CI einrichten

### DIFF
--- a/.github/workflows/build-test-and-deploy-if-master.yml
+++ b/.github/workflows/build-test-and-deploy-if-master.yml
@@ -1,51 +1,38 @@
-name: Node.js CI (Run Karma Tests)
+name: EventLogs-CI/CD-Pipeline
 
-on:
-  push:
-    branches: [ "master", "EL-49" ] # TODO
-  pull_request:
-    branches: [ "master" ]
+on: [ push ]
 
 jobs:
-  build-and-test:
+  build-test-and-deploy-if-master:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
-    - name: Checkout
+    - name: Checkout Git-Repo
       uses: actions/checkout@v3
 
-    - name: Setup Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '16.x'
         cache: 'npm'
 
     - name: Setup Chrome
       uses: browser-actions/setup-chrome@latest
 
-    - name: Install Dependencies in CI-Environment
+    - name: Install NPM-Dependencies
       run: npm ci
 
-    - name: Run tests in headless environment
+    - name: Run Karma tests headless
       run: npm run github-actions-test
 
     - name: Build Angular project
       run: npm run github-actions-build
 
     - name: Deploy to Github Pages if branch is master
-      if: ${{ github.ref == 'refs/heads/EL-49' }} # TODO
+      if: ${{ github.ref == 'refs/heads/master' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
           enable_jekyll: true
-
-
-
-
-

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,4 +27,5 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm i -D puppeteer karma-chrome-launcher
-    - run: npm test
+    - run: npm run github-actions-test
+

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,7 +38,7 @@ jobs:
       run: npm run github-actions-build
 
     - name: Deploy to Github Pages if branch is master
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: ${{ github.ref == 'refs/heads/EL-49' }} # TODO
       uses: peaceiris/actions-gh-pages@v3
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,8 +22,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - name: Setup Angular Full CI
-      uses: colbyhill21/angular-full-ci@v1.0
     - name: Setup Chrome
       uses: browser-actions/setup-chrome@latest
     - run: npm ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,27 @@
+name: Node.js CI (Run Karma Tests)
+
+on:
+  push:
+    branches: [ "master", "EL-49" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,4 +29,4 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm i -D puppeteer karma-chrome-launcher
-    - run: ng test --watch=false --browsers=ChromeHeadless
+    - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,11 +17,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - name: Setup Angular Full CI
+      uses: colbyhill21/angular-full-ci@v1.0
     - name: Setup Chrome
       uses: browser-actions/setup-chrome@latest
     - run: npm ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,6 +22,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - name: Setup Chrome
+      uses: browser-actions/setup-chrome@latest
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,12 +2,12 @@ name: Node.js CI (Run Karma Tests)
 
 on:
   push:
-    branches: [ "master", "EL-49" ]
+    branches: [ "master", "EL-49" ] # TODO
   pull_request:
     branches: [ "master" ]
 
 jobs:
-  build:
+  build-and-test:
 
     runs-on: ubuntu-latest
 
@@ -16,16 +16,36 @@ jobs:
         node-version: [16.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+
     - name: Setup Chrome
       uses: browser-actions/setup-chrome@latest
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm i -D puppeteer karma-chrome-launcher
-    - run: npm run github-actions-test
+
+    - name: Install Dependencies in CI-Environment
+      run: npm ci
+
+    - name: Run tests in headless environment
+      run: npm run github-actions-test
+
+    - name: Build Angular project
+      run: npm run github-actions-build
+
+    - name: Deploy to Github Pages
+      if: sucess() && ${{ github.ref == 'refs/heads/main' }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          enable_jekyll: true
+
+
+
+
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,7 +38,7 @@ jobs:
       run: npm run github-actions-build
 
     - name: Deploy to Github Pages
-      if: sucess() && ${{ github.ref == 'refs/heads/main' }}
+      if: ( sucess() && ${{ github.ref == 'refs/heads/master' }} )
       uses: peaceiris/actions-gh-pages@v3
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,8 +37,8 @@ jobs:
     - name: Build Angular project
       run: npm run github-actions-build
 
-    - name: Deploy to Github Pages
-      if: ( sucess() && ${{ github.ref == 'refs/heads/master' }} )
+    - name: Deploy to Github Pages if branch is master
+      if: ${{ github.ref == 'refs/heads/master' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,4 +26,5 @@ jobs:
       uses: browser-actions/setup-chrome@latest
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test
+    - run: npm i -D puppeteer karma-chrome-launcher
+    - run: ng test --watch=false --browsers=ChromeHeadless

--- a/github-actions.karma.conf.js
+++ b/github-actions.karma.conf.js
@@ -31,12 +31,13 @@ module.exports = function (config) {
         { type: 'lcov' }
       ],
       check: {
-        global: {
-          statements: 80,
-          branches: 80,
-            functions: 80,
-            lines: 80
-        }
+          emitWarning: true,
+          global: {
+              statements: 80,
+              branches: 80,
+              functions: 80,
+              lines: 80
+          }
       }
     },
       reporters: ['progress', 'kjhtml'],

--- a/github-actions.karma.conf.js
+++ b/github-actions.karma.conf.js
@@ -1,0 +1,56 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/event_logs'),
+      subdir: '.',
+      reporters: [
+        { type: 'lcov' }
+      ],
+      check: {
+        global: {
+          statements: 80,
+          branches: 80,
+            functions: 80,
+            lines: 80
+        }
+      }
+    },
+      reporters: ['progress', 'kjhtml'],
+      port: 9876,
+      colors: true,
+      logLevel: config.LOG_INFO,
+      autoWatch: true,
+      browsers: ['ChromeHeadless'],
+      customLaunchers: {
+          ChromeHeadlessCI: {
+              base: 'ChromeHeadless',
+              flags: ['--no-sandbox']
+          }
+      },
+      singleRun: true
+  });
+};

--- a/github-actions.karma.conf.js
+++ b/github-actions.karma.conf.js
@@ -2,56 +2,56 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 module.exports = function (config) {
-  config.set({
-    basePath: '',
-    frameworks: ['jasmine', '@angular-devkit/build-angular'],
-    plugins: [
-      require('karma-jasmine'),
-      require('karma-chrome-launcher'),
-      require('karma-jasmine-html-reporter'),
-      require('karma-coverage'),
-      require('@angular-devkit/build-angular/plugins/karma')
-    ],
-    client: {
-      jasmine: {
-        // you can add configuration options for Jasmine here
-        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
-        // for example, you can disable the random execution with `random: false`
-        // or set a specific seed with `seed: 4321`
-      },
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
-    },
-    jasmineHtmlReporter: {
-      suppressAll: true // removes the duplicated traces
-    },
-    coverageReporter: {
-      dir: require('path').join(__dirname, './coverage/event_logs'),
-      subdir: '.',
-      reporters: [
-        { type: 'lcov' }
-      ],
-      check: {
-          emitWarning: true,
-          global: {
-              statements: 80,
-              branches: 80,
-              functions: 80,
-              lines: 80
-          }
-      }
-    },
-      reporters: ['progress', 'kjhtml'],
-      port: 9876,
-      colors: true,
-      logLevel: config.LOG_INFO,
-      autoWatch: true,
-      browsers: ['ChromeHeadless'],
-      customLaunchers: {
-          ChromeHeadlessCI: {
-              base: 'ChromeHeadless',
-              flags: ['--no-sandbox']
-          }
-      },
-      singleRun: true
-  });
+    config.set({
+        basePath: '',
+        frameworks: ['jasmine', '@angular-devkit/build-angular'],
+        plugins: [
+            require('karma-jasmine'),
+            require('karma-chrome-launcher'),
+            require('karma-jasmine-html-reporter'),
+            require('karma-coverage'),
+            require('@angular-devkit/build-angular/plugins/karma')
+        ],
+        client: {
+            jasmine: {
+                // you can add configuration options for Jasmine here
+                // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+                // for example, you can disable the random execution with `random: false`
+                // or set a specific seed with `seed: 4321`
+            },
+            clearContext: false // leave Jasmine Spec Runner output visible in browser
+        },
+        jasmineHtmlReporter: {
+            suppressAll: true // removes the duplicated traces
+        },
+        coverageReporter: {
+            dir: require('path').join(__dirname, './coverage/event_logs'),
+            subdir: '.',
+            reporters: [
+                { type: 'lcov' }
+            ],
+            check: {
+                emitWarning: true,
+                global: {
+                    statements: 80,
+                    branches: 80,
+                    functions: 80,
+                    lines: 80
+                }
+            }
+        },
+        reporters: ['progress', 'kjhtml'],
+        port: 9876,
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: true,
+        browsers: ['ChromeHeadless'],
+        customLaunchers: {
+            ChromeHeadlessCI: {
+                base: 'ChromeHeadless',
+                flags: ['--no-sandbox']
+            }
+        },
+        singleRun: true
+    });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = function (config) {
       colors: true,
       logLevel: config.LOG_INFO,
       autoWatch: true,
-      browsers: ['Chrome', 'ChromeHeadless', 'ChromeHeadlessCI'],
+      browsers: ['ChromeHeadless', 'ChromeHeadlessCI'],
       customLaunchers: {
           ChromeHeadlessCI: {
               base: 'ChromeHeadless',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,56 +2,50 @@
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
 module.exports = function (config) {
-  config.set({
-    basePath: '',
-    frameworks: ['jasmine', '@angular-devkit/build-angular'],
-    plugins: [
-      require('karma-jasmine'),
-      require('karma-chrome-launcher'),
-      require('karma-jasmine-html-reporter'),
-      require('karma-coverage'),
-      require('@angular-devkit/build-angular/plugins/karma')
-    ],
-    client: {
-      jasmine: {
-        // you can add configuration options for Jasmine here
-        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
-        // for example, you can disable the random execution with `random: false`
-        // or set a specific seed with `seed: 4321`
-      },
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
-    },
-    jasmineHtmlReporter: {
-      suppressAll: true // removes the duplicated traces
-    },
-    coverageReporter: {
-      dir: require('path').join(__dirname, './coverage/event_logs'),
-      subdir: '.',
-      reporters: [
-        { type: 'lcov' }
-      ],
-      check: {
-        global: {
-          statements: 80,
-          branches: 80,
-            functions: 80,
-            lines: 80
-        }
-      }
-    },
-      reporters: ['progress', 'kjhtml'],
-      port: 9876,
-      colors: true,
-      logLevel: config.LOG_INFO,
-      autoWatch: true,
-      browsers: ['ChromeHeadless', 'ChromeHeadlessCI'],
-      customLaunchers: {
-          ChromeHeadlessCI: {
-              base: 'ChromeHeadless',
-              flags: ['--no-sandbox']
-          }
-      },
-      singleRun: false,
-      restartOnFileChange: true
-  });
+    config.set({
+        basePath: '',
+        frameworks: ['jasmine', '@angular-devkit/build-angular'],
+        plugins: [
+            require('karma-jasmine'),
+            require('karma-chrome-launcher'),
+            require('karma-jasmine-html-reporter'),
+            require('karma-coverage'),
+            require('@angular-devkit/build-angular/plugins/karma')
+        ],
+        client: {
+            jasmine: {
+                // you can add configuration options for Jasmine here
+                // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+                // for example, you can disable the random execution with `random: false`
+                // or set a specific seed with `seed: 4321`
+            },
+            clearContext: false // leave Jasmine Spec Runner output visible in browser
+        },
+        jasmineHtmlReporter: {
+            suppressAll: true // removes the duplicated traces
+        },
+        coverageReporter: {
+            dir: require('path').join(__dirname, './coverage/event_logs'),
+            subdir: '.',
+            reporters: [
+                { type: 'lcov' }
+            ],
+            check: {
+                global: {
+                    statements: 80,
+                    branches: 80,
+                    functions: 80,
+                    lines: 80
+                }
+            }
+        },
+        reporters: ['progress', 'kjhtml'],
+        port: 9876,
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: true,
+        browsers: ['Chrome'],
+        singleRun: false,
+        restartOnFileChange: true
+    });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,6 +31,7 @@ module.exports = function (config) {
                 { type: 'lcov' }
             ],
             check: {
+                emitWarning: true,
                 global: {
                     statements: 80,
                     branches: 80,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,18 +34,24 @@ module.exports = function (config) {
         global: {
           statements: 80,
           branches: 80,
-          functions: 80,
-          lines: 80
+            functions: 80,
+            lines: 80
         }
       }
     },
-    reporters: ['progress', 'kjhtml'],
-    port: 9876,
-    colors: true,
-    logLevel: config.LOG_INFO,
-    autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false,
-    restartOnFileChange: true
+      reporters: ['progress', 'kjhtml'],
+      port: 9876,
+      colors: true,
+      logLevel: config.LOG_INFO,
+      autoWatch: true,
+      browsers: ['Chrome', 'ChromeHeadless', 'ChromeHeadlessCI'],
+      customLaunchers: {
+          ChromeHeadlessCI: {
+              base: 'ChromeHeadless',
+              flags: ['--no-sandbox']
+          }
+      },
+      singleRun: false,
+      restartOnFileChange: true
   });
 };

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "event_logs",
   "version": "0.0.0",
   "scripts": {
-    "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
-    "watch": "ng build --watch --configuration development",
-    "test": "ng test",
-    "lint": "ng lint",
-    "format": "ng lint --fix"
+      "ng": "ng",
+      "start": "ng serve",
+      "build": "ng build",
+      "watch": "ng build --watch --configuration development",
+      "test": "ng test",
+      "github-actions-test": "ng test --karma-config github-actions.karma.conf.js",
+      "lint": "ng lint",
+      "format": "ng lint --fix"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
       "watch": "ng build --watch --configuration development",
       "test": "ng test",
       "github-actions-test": "ng test --karma-config github-actions.karma.conf.js",
+      "github-actions-build": "ng build --output-path docs --base-href /event_logs/",
       "lint": "ng lint",
       "format": "ng lint --fix"
   },


### PR DESCRIPTION
Ausführung von:

* Tests mit Chrome Headless
* Build der Anwendung
* Deployment und Bereitstellung über Github-Pages (Nur wenn der Build vom Master-Branch aus erfolgt)

verfügbar ist die Anwendung dann entsprechend unter [https://eventlogs.github.io/event_logs/index.html](https://eventlogs.github.io/event_logs/index.html)