### PR TITLE
Rücksetzen vom File bei jedem Click

### DIFF
--- a/src/app/components/upload-button/upload-button.component.html
+++ b/src/app/components/upload-button/upload-button.component.html
@@ -4,6 +4,7 @@
         type="file"
         class="file-input"
         (change)="handleFileInput($event)"
+        onclick="this.value = null"
         #fileUpload />
     <div
         class="interactive-square"


### PR DESCRIPTION
Zum reproduzieren:

1. .log(txt) file einlesen mit click -> File search Dialog -> auswählen
2. xes file einlesen mit click -> File search Dialog -> auwählen
3. gleiches logfile aus 1. wieder auf die gleiche Art wie in 1. versuchen einzulesen

Result: Update des Graph erfolgt nicht

Behoben durch zurücksetzen des File Werts beim Click... / Tritt bei d&d nicht auf da hier direkt readAndEmitFile gerufen wird