### PR TITLE
El 72 traces anzahl labeln

### DIFF
--- a/src/app/services/layout.service.ts
+++ b/src/app/services/layout.service.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@angular/core';
 import { Diagram } from '../classes/diagram/diagram';
+import { Element } from '../classes/diagram/element';
 
 @Injectable({
     providedIn: 'root',
 })
 export class LayoutService {
-    private static readonly XOFFSET = 10;
+    public static readonly XOFFSET = 10;
     private static readonly YOFFSET = 50;
-    private static readonly XSTEP = 150;
-    private static readonly YSTEP = 50;
+    public  static readonly XSTEP = 150;
+    public static readonly YSTEP = 50;
 
     // Ordnet die Elemente des Diagrams an und gibt die maximalen Ausmaße der Zeichnung zurück
     public layout(diagram: Diagram): [number, number] {
@@ -16,26 +17,29 @@ export class LayoutService {
         let y = 0;
         let xMax = 0;
 
-        diagram.traces.forEach(trace => {
-            trace.svgElements[0].x =
-                trace.svgElements[0].x +
-                LayoutService.XOFFSET +
-                x * LayoutService.XSTEP;
-            trace.svgElements[0].y =
-                trace.svgElements[0].y +
-                LayoutService.YOFFSET +
+        let layoutTraceLabel = function(element: Element)
+        {
+            element.x += LayoutService.XOFFSET
+            element.y += LayoutService.YOFFSET +
                 y * LayoutService.YSTEP;
-            x++;
-            trace.events.forEach(el => {
-                el.svgElements.forEach(svg => {
-                    svg.x =
-                        svg.x +
-                        LayoutService.XOFFSET +
-                        (x - 0.5) * LayoutService.XSTEP;
-                    svg.y =
-                        svg.y + LayoutService.YOFFSET + y * LayoutService.YSTEP;
-                });
+        }
 
+        let layoutEventElements = function(elements: Element[])
+        {
+            elements.forEach(svg => {
+                svg.x +=
+                    LayoutService.XOFFSET +
+                    (x - 0.5) * LayoutService.XSTEP;
+                svg.y +=
+                    LayoutService.YOFFSET + y * LayoutService.YSTEP;
+            });
+        }
+
+        diagram.traces.forEach(trace => {
+            layoutTraceLabel(trace.svgElements[0]);
+            x++;
+            trace.events.forEach(event => {
+                layoutEventElements(event.svgElements)
                 x++;
             });
             if (x > xMax) {
@@ -45,10 +49,10 @@ export class LayoutService {
             y++;
         });
 
-        return this.calculateLayoutSize(xMax, y);
+        return LayoutService.calculateLayoutSize(xMax, y);
     }
 
-    private calculateLayoutSize(xMax: number, y: number): [number, number] {
+    private static calculateLayoutSize(xMax: number, y: number): [number, number] {
         // Halbe Stepsize wird wieder abgezogen da die Elemente in der Zeichnug ihren Nullpunkt in der Mitte haben
         return [
             LayoutService.XOFFSET +

--- a/src/app/services/svg.service.ts
+++ b/src/app/services/svg.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Diagram } from '../classes/diagram/diagram';
 import { Element, ElementType } from '../classes/diagram/element';
+import { LayoutService } from '../services/layout.service';
 
 @Injectable({
     providedIn: 'root',
@@ -29,6 +30,13 @@ export class SvgService {
     private readonly widthTraceBorderPerElement = 150;
     private readonly widthTraceBorderOffset = 70;
 
+    private readonly midPointOfHeight = 0;
+    private readonly boxWidth = 125;
+    private readonly boxHeight = 40;
+    private readonly peakOffset = 10;
+    private readonly topXCoordinate = 0 - (this.boxHeight / 2);
+    private readonly leftXCoordinate = -20;
+
     private activityColorMap = new Map<String, number>();
 
     /// Erstellt alle benötigten SVGElemente für ein gegebenes Diagram
@@ -53,7 +61,7 @@ export class SvgService {
                 result.push(traceBorder);
             }
 
-            const textNumber = this.createSvgForText(
+            const textNumber = this.createSvgForTraceCountLabel(
                 trace.svgElements[0],
                 trace.count.toString() +
                     (trace.count == 1 ? " trace" : " traces")
@@ -103,7 +111,12 @@ export class SvgService {
     private createBoxForElement(element: Element, fill: number): SVGElement {
         const svg = this.createSvgElement('polygon');
         svg.setAttribute('transform', `translate( ${element.x} ${element.y} )`);
-        svg.setAttribute('points', '-20,-20 125,-20 135,0 125,20 -20,20 -10,0');
+        svg.setAttribute('points', `${this.leftXCoordinate},${this.topXCoordinate}
+                                                     ${this.boxWidth},${this.topXCoordinate}
+                                                     ${this.boxWidth + this.peakOffset},${this.midPointOfHeight}
+                                                     ${this.boxWidth},${this.boxHeight/2}
+                                                     ${this.leftXCoordinate},${this.boxHeight/2}
+                                                     ${this.leftXCoordinate + this.peakOffset},${this.midPointOfHeight}`);
         svg.setAttribute(
             'fill',
             this.backgroundColors[fill % this.backgroundColors.length]
@@ -133,6 +146,18 @@ export class SvgService {
             }
         }
         return [text, ''];
+    }
+
+    private createSvgForTraceCountLabel(element: Element, text: String): SVGElement {
+        const svg = this.createSvgElement('text');
+        svg.setAttribute('x', `${element.x - this.XTEXTOFFSET}`);
+        svg.setAttribute('y', `${element.y}`);
+        let stringWidth = this.GetStringWidth(text);
+        svg.setAttribute('width', `${stringWidth}`);
+        svg.setAttribute('font', this.FONT);
+        svg.textContent = text.toString();
+        element.registerSvg(svg);
+        return svg;
     }
 
     private createSvgForText(element: Element, text: String): SVGElement {

--- a/src/app/services/svg.service.ts
+++ b/src/app/services/svg.service.ts
@@ -31,11 +31,11 @@ export class SvgService {
     private readonly widthTraceBorderOffset = 70;
 
     private readonly midPointOfHeight = 0;
-    private readonly boxWidth = LayoutService.XSTEP - LayoutService.XOFFSET / 2;
+    private readonly boxWidth = 125;
     private readonly boxHeight = LayoutService.YSTEP - 10;
     private readonly peakOffset = 10;
     private readonly topXCoordinate = 0 - (this.boxHeight / 2);
-    private readonly leftXCoordinate = 0;
+    private readonly leftXCoordinate = -20;
 
     private activityColorMap = new Map<String, number>();
 

--- a/src/app/services/svg.service.ts
+++ b/src/app/services/svg.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Diagram } from '../classes/diagram/diagram';
 import { Element, ElementType } from '../classes/diagram/element';
-import { LayoutService } from '../services/layout.service';
+import { LayoutService } from "./layout.service";
 
 @Injectable({
     providedIn: 'root',
@@ -21,7 +21,7 @@ export class SvgService {
     ];
     private readonly FONT = '15px sans-Serif';
     private readonly MAXFONTWIDTH = 120;
-    private readonly XTEXTOFFSET = 5;
+    private readonly XTEXTOFFSET = 12.5;
     private readonly YTEXTOFFSET = 4;
     private readonly YNEXTROWOFFSET = 20;
 
@@ -31,11 +31,11 @@ export class SvgService {
     private readonly widthTraceBorderOffset = 70;
 
     private readonly midPointOfHeight = 0;
-    private readonly boxWidth = 125;
-    private readonly boxHeight = 40;
+    private readonly boxWidth = LayoutService.XSTEP - LayoutService.XOFFSET / 2;
+    private readonly boxHeight = LayoutService.YSTEP - 10;
     private readonly peakOffset = 10;
     private readonly topXCoordinate = 0 - (this.boxHeight / 2);
-    private readonly leftXCoordinate = -20;
+    private readonly leftXCoordinate = 0;
 
     private activityColorMap = new Map<String, number>();
 
@@ -52,7 +52,7 @@ export class SvgService {
             if (
                 trace.caseIds.every(val => selectedTraceCaseIds.includes(val))
             ) {
-                let traceBorder = this.createSelectedTraceBorder(
+                let traceBorder = SvgService.createSelectedTraceBorder(
                     trace.svgElements[0].x + this.xTraceBorderOffset,
                     trace.svgElements[0].y + this.yTraceBorderOffset,
                     trace.events.length * this.widthTraceBorderPerElement +
@@ -96,8 +96,8 @@ export class SvgService {
         return result;
     }
 
-    private createSelectedTraceBorder(x: number, y: number, width: number) {
-        const svg = this.createSvgElement('rect');
+    private static createSelectedTraceBorder(x: number, y: number, width: number) {
+        const svg = SvgService.createSvgElement('rect');
         svg.setAttribute('x', `${x}`);
         svg.setAttribute('y', `${y}`);
         svg.setAttribute('width', `${width}`);
@@ -109,7 +109,7 @@ export class SvgService {
     }
 
     private createBoxForElement(element: Element, fill: number): SVGElement {
-        const svg = this.createSvgElement('polygon');
+        const svg = SvgService.createSvgElement('polygon');
         svg.setAttribute('transform', `translate( ${element.x} ${element.y} )`);
         svg.setAttribute('points', `${this.leftXCoordinate},${this.topXCoordinate}
                                                      ${this.boxWidth},${this.topXCoordinate}
@@ -149,11 +149,9 @@ export class SvgService {
     }
 
     private createSvgForTraceCountLabel(element: Element, text: String): SVGElement {
-        const svg = this.createSvgElement('text');
-        svg.setAttribute('x', `${element.x - this.XTEXTOFFSET}`);
+        const svg = SvgService.createSvgElement('text');
+        svg.setAttribute('x', `${element.x}`);
         svg.setAttribute('y', `${element.y}`);
-        let stringWidth = this.GetStringWidth(text);
-        svg.setAttribute('width', `${stringWidth}`);
         svg.setAttribute('font', this.FONT);
         svg.textContent = text.toString();
         element.registerSvg(svg);
@@ -161,19 +159,19 @@ export class SvgService {
     }
 
     private createSvgForText(element: Element, text: String): SVGElement {
-        const svg = this.createSvgElement('text');
-        svg.setAttribute('x', `${element.x - this.XTEXTOFFSET}`);
+        const svg = SvgService.createSvgElement('text');
+        svg.setAttribute('x', `${element.x + this.XTEXTOFFSET}`);
         svg.setAttribute('y', `${element.y - this.YTEXTOFFSET}`);
         let stringWidth = this.GetStringWidth(text);
         if (stringWidth > this.MAXFONTWIDTH) {
             let subStrings = this.getSubStrings(text);
-            const svg1 = this.createSvgElement('tspan');
+            const svg1 = SvgService.createSvgElement('tspan');
             svg1.setAttribute('font', this.FONT);
             svg1.textContent = subStrings[0].toString();
-            const svg2 = this.createSvgElement('tspan');
+            const svg2 = SvgService.createSvgElement('tspan');
             svg2.setAttribute('font', this.FONT);
             svg2.textContent = subStrings[1].toString();
-            svg2.setAttribute('x', `${element.x - this.XTEXTOFFSET}`);
+            svg2.setAttribute('x', `${element.x + this.XTEXTOFFSET}`);
             svg2.setAttribute('dy', `${this.YNEXTROWOFFSET}` + 'px');
             svg.appendChild(svg1);
             svg.appendChild(svg2);
@@ -191,11 +189,10 @@ export class SvgService {
         canvas.setAttribute('height', '380px');
         var ctx = canvas.getContext('2d');
         ctx!.font = this.FONT;
-        var strWidth = ctx!.measureText(text.toString()).width;
-        return strWidth;
+        return ctx!.measureText(text.toString()).width;
     }
 
-    private createSvgElement(name: string): SVGElement {
+    private static createSvgElement(name: string): SVGElement {
         return document.createElementNS('http://www.w3.org/2000/svg', name);
     }
 }

--- a/src/app/services/svg.service.ts
+++ b/src/app/services/svg.service.ts
@@ -55,7 +55,8 @@ export class SvgService {
 
             const textNumber = this.createSvgForText(
                 trace.svgElements[0],
-                trace.count.toString()
+                trace.count.toString() +
+                    (trace.count == 1 ? " trace" : " traces")
             );
             result.push(textNumber);
             trace.events.forEach(ev => {


### PR DESCRIPTION
Hinter die Anzahl der traces das Wort "trace" bzw. "traces" hinzugefügt.

Wenn die Zahl größer wird, schiebt sich der Text im Moment hinter die erste Event-Box, um dies zu beheben, habe ich in den SVG- und Layout-Services angefangen ein Refactoring zu machen. Die Sache ist aber etwas verzwickter zu beheben, als mir das in unserem Mini-Sprint möglich war, drum würde ich ein Ticket ins Backlog aufnehmen, um daran noch weiter zu arbeiten.