### PR TITLE
EL-73: XES-Import und XES-Export verbessert / EL-78: Standard-Log geändert

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,10 +37,8 @@ export class AppComponent implements OnDestroy {
         this._sub = this.textareaFc.valueChanges
             .pipe(debounceTime(400))
             .subscribe(val => this.processSourceChange(val));
-        this.textareaFc.setValue(this.textareaExampleValue());
-        this._eventlogDataService.eventLog = this._logParserService.parse(
-            this.textareaExampleValue()
-        );
+
+        this.processXesImport(this.xesExampleValue());
 
         this._subSelectedTraces =
             this._displayService.selectedTraceCaseIds$.subscribe(
@@ -140,25 +138,6 @@ export class AppComponent implements OnDestroy {
         return this.textareaFc.value;
     }
 
-    textareaExampleValue() {
-        return (
-            '.type log\n' +
-            '.attributes\n' +
-            'case-id\n' +
-            'concept:name\n' +
-            'booleanValue\n' +
-            'intValue\n' +
-            'floatValue\n' +
-            'dateValue\n' +
-            'stringValue\n' +
-            '.events\n' +
-            '1 Auto true 1 1.3 2020-01-31 basadf\n' +
-            '1 Schiff true 2 2.3 2020-01-31 dasf\n' +
-            '2 BusBus false 3 4.5 2020-01-31 adsf\n' +
-            '2 Bus false 4 6.7 2020-01-31 adfd'
-        );
-    }
-
     updateViews() {
         this._displayService.displayEventLog(
             this._eventlogDataService.eventLog
@@ -173,5 +152,257 @@ export class AppComponent implements OnDestroy {
         }
 
         this.tracesDetailView?.refresh();
+    }
+
+    xesExampleValue() {
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>' +
+            '<log xes.version="1.0" xes.features="nested-attributes">' +
+            '<extension name="Lifecycle" prefix="lifecycle" uri="http://www.xes-standard.org/lifecycle.xesext"/>' +
+            '<extension name="Organizational" prefix="org" uri="http://www.xes-standard.org/org.xesext"/>' +
+            '<extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext"/>' +
+            '<extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext"/>' +
+            '<extension name="Semantic" prefix="semantic" uri="http://www.xes-standard.org/semantic.xesext"/>' +
+            '<global scope="trace">' +
+            '<string key="concept:name" value="__INVALID__"/>' +
+            '</global>' +
+            '<global scope="event">' +
+            '<string key="concept:name" value="__INVALID__"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '</global>' +
+            '<classifier name="MXML_Legacy_Classifier" keys="concept:name lifecycle:transition"/>' +
+            '<classifier name="Event_Name" keys="concept:name"/>' +
+            '<classifier name="Resource" keys="org:resource"/>' +
+            '<classifier name="Event_Name_AND_Resource" keys="concept:name org:resource"/>' +
+            '<string key="source" value="CPN Tools simulation"/>' +
+            '<string key="concept:name" value="repairExample.mxml"/>' +
+            '<string key="lifecycle:model" value="standard"/>' +
+            '<string key="description" value="Simulated process"/>' +
+            '<trace>' +
+            '<string key="concept:name" value="1"/>' +
+            '<string key="description" value="Simulated process instance"/>' +
+            '<event>' +
+            '<string key="concept:name" value="Register"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-02T12:23:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Analyze Defect"/>' +
+            '<string key="org:resource" value="Tester3"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-02T12:23:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Analyze Defect"/>' +
+            '<string key="defectType" value="6"/>' +
+            '<string key="org:resource" value="Tester3"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="phoneType" value="T2"/>' +
+            '<date key="time:timestamp" value="1970-01-02T12:30:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Repair (Complex)"/>' +
+            '<string key="org:resource" value="SolverC1"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-02T12:31:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Repair (Complex)"/>' +
+            '<string key="org:resource" value="SolverC1"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-02T12:49:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Test Repair"/>' +
+            '<string key="org:resource" value="Tester3"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-02T12:49:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Test Repair"/>' +
+            '<string key="numberRepairs" value="0"/>' +
+            '<string key="org:resource" value="Tester3"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="defectFixed" value="true"/>' +
+            '<date key="time:timestamp" value="1970-01-02T12:55:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Inform User"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-02T13:10:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Archive Repair"/>' +
+            '<string key="numberRepairs" value="0"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="defectFixed" value="true"/>' +
+            '<date key="time:timestamp" value="1970-01-02T13:10:00.000Z"/>' +
+            '</event>' +
+            '</trace>' +
+            '<trace>' +
+            '<string key="concept:name" value="10"/>' +
+            '<string key="description" value="Simulated process instance"/>' +
+            '<event>' +
+            '<string key="concept:name" value="Register"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:09:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Analyze Defect"/>' +
+            '<string key="org:resource" value="Tester2"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:09:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Analyze Defect"/>' +
+            '<string key="defectType" value="3"/>' +
+            '<string key="org:resource" value="Tester2"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="phoneType" value="T1"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:15:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Repair (Simple)"/>' +
+            '<string key="org:resource" value="SolverS1"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:35:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Repair (Simple)"/>' +
+            '<string key="org:resource" value="SolverS1"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:42:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Test Repair"/>' +
+            '<string key="org:resource" value="Tester6"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:42:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Test Repair"/>' +
+            '<string key="numberRepairs" value="1"/>' +
+            '<string key="org:resource" value="Tester6"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="defectFixed" value="false"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:48:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Restart Repair"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:54:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Repair (Simple)"/>' +
+            '<string key="org:resource" value="SolverS2"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:54:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Inform User"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-01T11:55:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Repair (Simple)"/>' +
+            '<string key="org:resource" value="SolverS2"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-01T12:03:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Test Repair"/>' +
+            '<string key="org:resource" value="Tester4"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-01T12:03:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Test Repair"/>' +
+            '<string key="numberRepairs" value="2"/>' +
+            '<string key="org:resource" value="Tester4"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="defectFixed" value="true"/>' +
+            '<date key="time:timestamp" value="1970-01-01T12:09:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Archive Repair"/>' +
+            '<string key="numberRepairs" value="2"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="defectFixed" value="true"/>' +
+            '<date key="time:timestamp" value="1970-01-01T12:14:00.000Z"/>' +
+            '</event>' +
+            '</trace>' +
+            '<trace>' +
+            '<string key="concept:name" value="100"/>' +
+            '<string key="description" value="Simulated process instance"/>' +
+            '<event>' +
+            '<string key="concept:name" value="Register"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-04T02:28:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Analyze Defect"/>' +
+            '<string key="org:resource" value="Tester4"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-04T02:28:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Analyze Defect"/>' +
+            '<string key="defectType" value="8"/>' +
+            '<string key="org:resource" value="Tester4"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="phoneType" value="T2"/>' +
+            '<date key="time:timestamp" value="1970-01-04T02:36:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Repair (Complex)"/>' +
+            '<string key="org:resource" value="SolverC1"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-04T02:52:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Repair (Complex)"/>' +
+            '<string key="org:resource" value="SolverC1"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-04T03:09:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Test Repair"/>' +
+            '<string key="org:resource" value="Tester1"/>' +
+            '<string key="lifecycle:transition" value="start"/>' +
+            '<date key="time:timestamp" value="1970-01-04T03:09:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Test Repair"/>' +
+            '<string key="numberRepairs" value="0"/>' +
+            '<string key="org:resource" value="Tester1"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="defectFixed" value="true"/>' +
+            '<date key="time:timestamp" value="1970-01-04T03:18:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Inform User"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<date key="time:timestamp" value="1970-01-04T03:20:00.000Z"/>' +
+            '</event>' +
+            '<event>' +
+            '<string key="concept:name" value="Archive Repair"/>' +
+            '<string key="numberRepairs" value="0"/>' +
+            '<string key="org:resource" value="System"/>' +
+            '<string key="lifecycle:transition" value="complete"/>' +
+            '<string key="defectFixed" value="true"/>' +
+            '<date key="time:timestamp" value="1970-01-04T03:28:00.000Z"/>' +
+            '</event>' +
+            '</trace>' +
+            '</log>'
+        );
     }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,6 +23,7 @@ export class AppComponent implements OnDestroy {
     private _sub: Subscription;
     private _subSelectedTraces: Subscription;
     public _selectedTraceCaseIds: Array<number> = [];
+    private _xesImport: boolean = false;
 
     constructor(
         private _logParserService: LogParserService,
@@ -83,9 +84,12 @@ export class AppComponent implements OnDestroy {
     private processSourceChange(newSource: string) {
         const result = this._logParserService.parse(newSource);
         if (result !== undefined) {
-            this._eventlogDataService.eventLog = result;
+            if (!this._xesImport) {
+                this._eventlogDataService.eventLog = result;
+            }
             this.updateViews();
         }
+        this._xesImport = false;
     }
 
     processImport([fileExtension, fileContent]: [string, string]) {
@@ -109,12 +113,14 @@ export class AppComponent implements OnDestroy {
     processXesImport(fileContent: string) {
         try {
             const result = this._xesParserService.parse(fileContent);
+            this._xesImport = true;
             if (result !== undefined) {
                 this._eventlogDataService.eventLog = result;
                 this.updateTextarea(this._logService.generate(result));
                 this.updateViews();
             }
         } catch (e) {
+            this._xesImport = false;
             if (e === XesParserService.PARSING_ERROR) {
                 alert(
                     'The uploaded XES file could not be parsed.\n' +
@@ -139,7 +145,7 @@ export class AppComponent implements OnDestroy {
             '.type log\n' +
             '.attributes\n' +
             'case-id\n' +
-            'activity\n' +
+            'concept:name\n' +
             'booleanValue\n' +
             'intValue\n' +
             'floatValue\n' +

--- a/src/app/components/traces-detail-view/traces-detail-view.component.ts
+++ b/src/app/components/traces-detail-view/traces-detail-view.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTable } from '@angular/material/table';
@@ -17,12 +17,12 @@ import { Subscription } from 'rxjs';
     templateUrl: './traces-detail-view.component.html',
     styleUrls: ['./traces-detail-view.component.scss'],
 })
-export class TracesDetailViewComponent implements AfterViewInit {
+export class TracesDetailViewComponent implements AfterViewInit, OnDestroy {
     @ViewChild(MatPaginator) paginator!: MatPaginator;
     @ViewChild(MatSort) sort!: MatSort;
     @ViewChild(MatTable) table!: MatTable<Event>;
     dataSource: TracesDetailViewDataSource;
-    subscription: Subscription; //TODO schließen der Subscription
+    subscription: Subscription;
 
     private readonly MAX_LETTERS_TABLE_ENTRY_WITHOUT_WHITE_SPACE = 20;
     private readonly MAX_LETTERS_TABLE_ENTRY_TOTAL = 120;
@@ -46,6 +46,10 @@ export class TracesDetailViewComponent implements AfterViewInit {
         this.dataSource.sort = this.sort;
         this.dataSource.paginator = this.paginator;
         this.table.dataSource = this.dataSource;
+    }
+
+    ngOnDestroy(): void {
+        this.subscription.unsubscribe();
     }
 
     public refresh(): void {

--- a/src/app/services/log-parser.service.spec.ts
+++ b/src/app/services/log-parser.service.spec.ts
@@ -29,7 +29,7 @@ describe('LogParserService', () => {
             '.type log\n' +
             '.attributes\n' +
             'case-id\n' +
-            'activity\n' +
+            'concept:name\n' +
             'booleanValue\n' +
             'intValue\n' +
             'floatValue\n' +
@@ -104,7 +104,7 @@ describe('LogParserService', () => {
             '.type log\n' +
             '.attributes\n' +
             'case-id\n' +
-            'activity\n' +
+            'concept:name\n' +
             'string key\n' +
             'other string key\n' +
             '.events\n' +

--- a/src/app/services/log-parser.service.ts
+++ b/src/app/services/log-parser.service.ts
@@ -26,7 +26,7 @@ export class LogParserService {
     private readonly _eventsElement = '.events';
 
     private readonly _caseIdElement = 'case-id';
-    private readonly _activityElement = 'activity';
+    private readonly _activityElement = 'concept:name';
     private readonly _escapeString = "'";
 
     constructor() {}

--- a/src/app/services/log.service.spec.ts
+++ b/src/app/services/log.service.spec.ts
@@ -74,7 +74,7 @@ describe('Log.ServiceService', () => {
             '.type log\n' +
             '.attributes\n' +
             'case-id\n' +
-            'activity\n' +
+            'concept:name\n' +
             'org:group\n' +
             'org:name\n' +
             'org:role\n' +

--- a/src/app/services/log.service.ts
+++ b/src/app/services/log.service.ts
@@ -16,7 +16,7 @@ import {
 })
 export class LogService {
     private readonly _caseIdElement = 'case-id';
-    private readonly _activityElement = 'activity';
+    private readonly _activityElement = 'concept:name';
     private readonly _undefinedValue = "''";
 
     constructor() {}

--- a/src/app/services/xes-parser.service.spec.ts
+++ b/src/app/services/xes-parser.service.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../classes/EventLog/eventlogattribute';
 import { Classifier } from '../classes/EventLog/classifier';
 
-describe('XmlParserService', () => {
+describe('XesParserService', () => {
     let service: XesParserService;
 
     beforeEach(() => {
@@ -47,21 +47,21 @@ describe('XmlParserService', () => {
             '      <float key="10609" value="2.538" />\n' +
             '   </float>\n' +
             '   <trace>\n' +
-            '      <string key="concept:name" value="1-147898401" />\n' +
+            '      <string key="concept:name" value="147898401" />\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Baden gehen" />\n' +
+            '         <string key="concept:name" value="Baden gehen" />\n' +
             '         <string key="org:role" value="A2_2" />\n' +
             '         <string key="ignoreEmptyValue" value="" />\n' +
             '         <string key="" value="ignoreEmptyKey" />\n' +
             '      </event>\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Schwimmen gehen" />\n' +
+            '         <string key="concept:name" value="Schwimmen gehen" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '      </event>\n' +
             '   </trace>\n' +
             '   <trace>\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Laufen gehen" />\n' +
+            '         <string key="concept:name" value="Laufen gehen" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '      </event>\n' +
             '   </trace>\n' +
@@ -78,7 +78,7 @@ describe('XmlParserService', () => {
             [new StringAttribute('UNKNOWN', 'concept:name')],
             [
                 new Trace(
-                    [new StringAttribute('1-147898401', 'concept:name')],
+                    [new StringAttribute('147898401', 'concept:name')],
                     [
                         new Event(
                             [new StringAttribute('A2_2', 'org:role')],
@@ -89,7 +89,7 @@ describe('XmlParserService', () => {
                             'Schwimmen gehen'
                         ),
                     ],
-                    0
+                    147898401
                 ),
                 new Trace(
                     [],
@@ -132,10 +132,10 @@ describe('XmlParserService', () => {
             '      <string key="product" value="UNKNOWN" />\n' +
             '      <string key="lifecycle:transition" value="UNKNOWN" />\n' +
             '   </global>\n' +
-            '   <classifier name="Activity classifier" keys="concept:name lifecycle:transition" />\n' +
-            '   <classifier name="Activity classifier" keys="concept:name lifecycle:transition" />\n' +
-            '   <classifier name="Activity classifier activityNameNL" keys="activityNameNL lifecycle:transition" />\n' +
-            '   <classifier name="Activity classifier activityNameEN" keys="activityNameEN lifecycle:transition" />\n' +
+            '   <classifier name="Activity_classifier" keys="concept:name lifecycle:transition" />\n' +
+            '   <classifier name="Activity_classifier" keys="concept:name lifecycle:transition" />\n' +
+            '   <classifier name="Activity_classifier_activityNameNL" keys="activityNameNL lifecycle:transition" />\n' +
+            '   <classifier name="Activity_classifier_activityNameEN" keys="activityNameEN lifecycle:transition" />\n' +
             '   <classifier name="Resource" keys="org:resource" />\n' +
             '   <float key="meta_org:resource_events_standard_deviation" value="19.944">\n' +
             '      <float key="10609" value="2.538" />\n' +
@@ -150,42 +150,38 @@ describe('XmlParserService', () => {
             '      <int key="UNKNOWN" value="262200" />\n' +
             '   </int>\n' +
             '   <trace>\n' +
-            '      <string key="concept:name" value="1-147898401" />\n' +
+            '      <string key="concept:name" value="147898401" />\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Aktivitätswert" />\n' +
+            '         <string key="concept:name" value="Aktivitätswert" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '         <string key="org:role" value="A2_2" />\n' +
-            '         <string key="concept:name" value="Accepted" />\n' +
             '         <string key="impact" value="Medium" />\n' +
             '         <string key="product" value="PROD753" />\n' +
             '         <date key="time:timestamp" value="2006-11-07T10:00:36+01:00" />\n' +
             '         <string key="lifecycle:transition" value="In Progress" />\n' +
             '      </event>\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Aktivitätswert" />\n' +
+            '         <string key="concept:name" value="Aktivitätswert" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '         <string key="org:role" value="A2_2" />\n' +
-            '         <string key="concept:name" value="Accepted" />\n' +
             '         <string key="impact" value="Medium" />\n' +
             '         <string key="product" value="PROD753" />\n' +
             '         <date key="time:timestamp" value="2006-11-07T13:05:44+01:00" />\n' +
             '         <string key="lifecycle:transition" value="In Progress" />\n' +
             '      </event>\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Aktivitätswert" />\n' +
+            '         <string key="concept:name" value="Aktivitätswert" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '         <string key="org:role" value="A2_2" />\n' +
-            '         <string key="concept:name" value="Accepted" />\n' +
             '         <string key="impact" value="Medium" />\n' +
             '         <string key="product" value="PROD753" />\n' +
             '         <date key="time:timestamp" value="2009-12-02T14:24:32+01:00" />\n' +
             '         <string key="lifecycle:transition" value="Wait" />\n' +
             '      </event>\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Aktivitätswert" />\n' +
+            '         <string key="concept:name" value="Aktivitätswert" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '         <string key="org:role" value="A2_2" />\n' +
-            '         <string key="concept:name" value="Accepted" />\n' +
             '         <string key="impact" value="Medium" />\n' +
             '         <string key="product" value="PROD753" />\n' +
             '         <date key="time:timestamp" value="2011-09-03T07:09:09+02:00" />\n' +
@@ -193,19 +189,18 @@ describe('XmlParserService', () => {
             '      </event>\n' +
             '   </trace>\n' +
             '   <trace>\n' +
-            '      <string key="concept:name" value="1-165554831" />\n' +
+            '      <string key="concept:name" value="165554831" />\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Aktivitätswert" />\n' +
+            '         <string key="concept:name" value="Aktivitätswert" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '         <string key="org:role" value="A2_2" />\n' +
-            '         <string key="concept:name" value="Accepted" />\n' +
             '         <string key="impact" value="Medium" />\n' +
             '         <string key="product" value="PROD753" />\n' +
             '         <date key="time:timestamp" value="2007-03-20T09:06:25+01:00" />\n' +
             '         <string key="lifecycle:transition" value="In Progress" />\n' +
             '      </event>\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Aktivitätswert" />\n' +
+            '         <string key="concept:name" value="Aktivitätswert" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '         <string key="impact" value="Medium" />\n' +
             '         <string key="product" value="PROD753" />\n' +
@@ -213,7 +208,7 @@ describe('XmlParserService', () => {
             '         <string key="lifecycle:transition" value="Wait" />\n' +
             '      </event>\n' +
             '      <event>\n' +
-            '         <string key="activity" value="Aktivitätswert" />\n' +
+            '         <string key="concept:name" value="Aktivitätswert" />\n' +
             '         <string key="org:group" value="Org line A2" />\n' +
             '         <date key="time:timestamp" value="2011-09-03T07:10:53+02:00" />\n' +
             '         <string key="lifecycle:transition" value="In Progress" />\n' +

--- a/src/app/services/xes-parser.service.ts
+++ b/src/app/services/xes-parser.service.ts
@@ -314,7 +314,6 @@ export class XesParserService {
         const filterAttributes = attributes.filter(
             attr => attr.key === 'concept:name' || attr.key === 'case-id'
         );
-        console.log(filterAttributes);
         if (filterAttributes.length > 0) {
             return parseInt(filterAttributes[0].value);
         }

--- a/src/app/services/xes-parser.service.ts
+++ b/src/app/services/xes-parser.service.ts
@@ -40,7 +40,7 @@ export class XesParserService {
     private readonly _keysToken = 'KEYS';
     private readonly _keyToken = 'KEY';
     private readonly _valueToken = 'VALUE';
-    private readonly _activityEventLogAttributeKey = 'activity';
+    private readonly _activityEventLogAttributeKey = 'concept:name';
     private readonly _eventScopeValue = 'event';
     private readonly _traceScopeValue = 'trace';
 
@@ -191,10 +191,15 @@ export class XesParserService {
             return undefined;
         }
         const attributes = this.extractEventLogAttributes(traceObj);
+        const extractedCaseId = this.extractCaseId(attributes);
         const events: Event[] = this.convertToEvents(
             traceObj[this._eventToken]
         );
-        return new Trace(attributes, events, caseId);
+        return new Trace(
+            attributes,
+            events,
+            extractedCaseId ? extractedCaseId : caseId
+        );
     }
 
     private convertToEvents(eventsObj: any): Event[] {
@@ -303,5 +308,16 @@ export class XesParserService {
                 );
                 return undefined;
         }
+    }
+
+    private extractCaseId(attributes: EventLogAttribute[]): number | undefined {
+        const filterAttributes = attributes.filter(
+            attr => attr.key === 'concept:name' || attr.key === 'case-id'
+        );
+        console.log(filterAttributes);
+        if (filterAttributes.length > 0) {
+            return parseInt(filterAttributes[0].value);
+        }
+        return undefined;
     }
 }

--- a/src/app/services/xes.service.spec.ts
+++ b/src/app/services/xes.service.spec.ts
@@ -66,11 +66,16 @@ describe('XesService', () => {
 
         let expected_string = format(
             '<?xml version="1.0" encoding="UTF-8" ?>' +
-                '<log xes.version="2.0">' +
+                '<log xes.version="1.0" xes.features="nested-attributes">' +
+                '<extension name="Lifecycle" prefix="lifecycle" uri="http://www.xes-standard.org/lifecycle.xesext"/>' +
+                '<extension name="Organizational" prefix="org" uri="http://www.xes-standard.org/org.xesext"/>' +
+                '<extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext"/>' +
+                '<extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext"/>' +
+                '<extension name="Semantic" prefix="semantic" uri="http://www.xes-standard.org/semantic.xesext"/>' +
                 '<trace>' +
-                '<string key="case-id" value="1" />' +
+                '<string key="concept:name" value="1" />' +
                 '<event>' +
-                '<string key="activity" value="Auto" />' +
+                '<string key="concept:name" value="Auto" />' +
                 '<boolean key="booleanValue" value="true" />' +
                 '<int key="intValue" value="1" />' +
                 '<float key="floatValue" value="1.3" />' +

--- a/src/app/services/xes.service.ts
+++ b/src/app/services/xes.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Classifier } from '../classes/EventLog/classifier';
 import { Event } from '../classes/EventLog/event';
 import { EventLog } from '../classes/EventLog/eventlog';
 import {
@@ -24,7 +25,42 @@ export class XesService {
      */
     public generate(eventLog: EventLog): string {
         let xesString = '<?xml version="1.0" encoding="UTF-8" ?>';
-        xesString += '<log xes.version="2.0">';
+        xesString += '<log xes.version="1.0" xes.features="nested-attributes">';
+        xesString +=
+            '<extension name="Lifecycle" prefix="lifecycle" uri="http://www.xes-standard.org/lifecycle.xesext"/>';
+        xesString +=
+            '<extension name="Organizational" prefix="org" uri="http://www.xes-standard.org/org.xesext"/>';
+        xesString +=
+            '<extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext"/>';
+        xesString +=
+            '<extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext"/>';
+        xesString +=
+            '<extension name="Semantic" prefix="semantic" uri="http://www.xes-standard.org/semantic.xesext"/>';
+
+        if (eventLog.globalTraceAttributes.length > 0) {
+            xesString += '<global scope="trace">';
+            eventLog.globalTraceAttributes.forEach(attribute => {
+                xesString += XesService.getAttributeRepresentation(attribute);
+            });
+            xesString += '</global>';
+        }
+
+        if (eventLog.globalEventAttributes.length > 0) {
+            xesString += '<global scope="event">';
+            eventLog.globalEventAttributes.forEach(attribute => {
+                xesString += XesService.getAttributeRepresentation(attribute);
+            });
+            xesString += '</global>';
+        }
+
+        eventLog.classifiers.forEach(classifier => {
+            xesString += this.getClassifierRepresentation(classifier);
+        });
+
+        eventLog.attributes.forEach(attribute => {
+            xesString += XesService.getAttributeRepresentation(attribute);
+        });
+
         eventLog.traces.forEach(trace => {
             xesString += this.getTraceRepresentation(trace);
         });
@@ -32,9 +68,21 @@ export class XesService {
         return format(xesString);
     }
 
+    private getClassifierRepresentation(classifier: Classifier): string {
+        let classifierString = '<classifier name="' + classifier.name + '"';
+        classifierString += 'keys="' + classifier.keys.join(' ') + '"/>';
+        return classifierString;
+    }
+
     private getTraceRepresentation(trace: Trace): string {
         let traceString = '<trace>';
-        traceString += '<string key="case-id" value="' + trace.caseId + '" />';
+        traceString +=
+            '<string key="concept:name" value="' + trace.caseId + '" />';
+        trace.attributes.forEach(attribute => {
+            if (attribute.key !== 'concept:name') {
+                traceString += XesService.getAttributeRepresentation(attribute);
+            }
+        });
         trace.events.forEach(event => {
             traceString += this.getEventRepresentation(event);
         });
@@ -45,7 +93,7 @@ export class XesService {
     private getEventRepresentation(event: Event): string {
         let eventString = '<event>';
         eventString +=
-            '<string key="activity" value="' + event.activity + '" />';
+            '<string key="concept:name" value="' + event.activity + '" />';
         event.attributes.forEach(attribute => {
             eventString += XesService.getAttributeRepresentation(attribute);
         });

--- a/src/assets/test/xes.xsd
+++ b/src/assets/test/xes.xsd
@@ -1,42 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-    <!-- This file describes the XML serialization of the XES format for event log data. -->
-    <!-- For more information about XES, visit http://www.xes−standard.org/ -->
-    <!-- (c) 2014 by IEEE Task Force on Process Mining (http: //www.win.tue.nl/ieetfpm) -->
-    <!-- Date: January 10, 2014 -->
-    <!-- Version 1.2 -->
-    <!-- Author: Eric Verbeek (h.m.w.verbeek@tue. nl ) -->
-    <!-- Change: Added list and container attribute types -->
-    <!-- Date: June 12, 2012 -->
-    <!-- Version: 1.1 -->
-    <!-- Author: Christian Günther (christian@fluxicom.com) -->
-    <!-- Author: Eric Verbeek (h.m.w.verbeek@tue. nl ) -->
-    <!-- Change: Added AttributableType ( list of attribute types now occurs only once) -->
-    <!-- Change: Added id type -->
-    <!-- Change: Made xes.features and openxes.version optional -->
-    <!-- Date: November 25 , 2009 -->
-    <!-- Version: 1.0 -->
-    <!-- Author: Christian Günther (christian@fluxicom.com) -->
-    <!-- Every XES XML Serialization needs to contain exactly one log element -->
     <xs:element name="log" type="LogType"/>
     <!-- Attributables -->
+    <xs:group name="AttributableGroup">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="string" type="AttributeStringType"/>
+                <xs:element name="date" type="AttributeDateType"/>
+                <xs:element name="int" type="AttributeIntType"/>
+                <xs:element name="float" type="AttributeFloatType"/>
+                <xs:element name="boolean" type="AttributeBooleanType"/>
+                <xs:element name="id" type="AttributeIDType"/>
+                <xs:element name="list" type="AttributeListType"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
     <xs:complexType name="AttributableType">
-        <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element name="string" minOccurs="0" maxOccurs="unbounded" type="AttributeStringType" />
-            <xs:element name="date" minOccurs="0" maxOccurs="unbounded" type="AttributeDateType" />
-            <xs:element name="int" minOccurs="0" maxOccurs="unbounded" type="AttributeIntType" />
-            <xs:element name="float" minOccurs="0" maxOccurs="unbounded" type="AttributeFloatType" />
-            <xs:element name="boolean" minOccurs="0" maxOccurs="unbounded" type="AttributeBooleanType" />
-            <xs:element name="id" minOccurs="0" maxOccurs="unbounded" type="AttributeIDType"/>
-            <xs:element name="list" minOccurs="0" maxOccurs="unbounded" type="AttributeListType" />
-            <xs:element name="container" minOccurs="0" maxOccurs="unbounded" type="AttributeContainerType" />
-        </xs:choice>
+        <xs:group ref="AttributableGroup"/>
     </xs:complexType>
     <!-- String attribute -->
     <xs:complexType name="AttributeStringType">
         <xs:complexContent>
             <xs:extension base="AttributeType">
-                <xs:attribute name="value" use="required" type="xs:string"/>
+                <xs:attribute name="value" type="xs:string" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -44,7 +30,7 @@
     <xs:complexType name="AttributeDateType">
         <xs:complexContent>
             <xs:extension base="AttributeType">
-                <xs:attribute name="value" use="required" type="xs:dateTime"/>
+                <xs:attribute name="value" type="xs:dateTime" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -52,15 +38,15 @@
     <xs:complexType name="AttributeIntType">
         <xs:complexContent>
             <xs:extension base="AttributeType">
-                <xs:attribute name="value" use="required" type="xs:long"/>
+                <xs:attribute name="value" type="xs:long" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-    <!-- Floating−point attribute -->
+    <!-- Floating-point attribute -->
     <xs:complexType name="AttributeFloatType">
         <xs:complexContent>
             <xs:extension base="AttributeType">
-                <xs:attribute name="value" use="required" type="xs:double"/>
+                <xs:attribute name="value" type="xs:double" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -68,7 +54,7 @@
     <xs:complexType name="AttributeBooleanType">
         <xs:complexContent>
             <xs:extension base="AttributeType">
-                <xs:attribute name="value" use="required" type="xs:boolean"/>
+                <xs:attribute name="value" type="xs:boolean" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -76,85 +62,67 @@
     <xs:complexType name="AttributeIDType">
         <xs:complexContent>
             <xs:extension base="AttributeType">
-                <xs:attribute name="value" use="required" type="xs:string"/>
+                <xs:attribute name="value" type="xs:string" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
     <!-- List attribute -->
     <xs:complexType name="AttributeListType">
         <xs:complexContent>
-            <xs:extension base="AttributeType"></xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-    <!-- Container attribute -->
-    <xs:complexType name="AttributeContainerType">
-        <xs:complexContent>
-            <xs:extension base="AttributableType"></xs:extension>
+            <xs:extension base="AttributeType">
+                <xs:sequence>
+                    <xs:element name="values" type="AttributeType"/>
+                </xs:sequence>
+            </xs:extension>
         </xs:complexContent>
     </xs:complexType>
     <!-- Extension definition -->
     <xs:complexType name="ExtensionType">
-        <xs:attribute name="name" use="required" type="xs:NCName"/>
-        <xs:attribute name="prefix" use="required" type="xs:NCName"/>
-        <xs:attribute name="uri" use="required" type="xs:anyURI"/>
+        <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="prefix" type="xs:NCName" use="required"/>
+        <xs:attribute name="uri" type="xs:anyURI" use="required"/>
     </xs:complexType>
     <!-- Globals definition -->
     <xs:complexType name="GlobalsType">
-        <xs:complexContent>
-            <xs:extension base="AttributableType">
-                <xs:attribute name="scope" type="xs:NCName" use="required"/>
-            </xs:extension>
-        </xs:complexContent>
+        <xs:group ref="AttributableGroup"/>
+        <xs:attribute name="scope" type="xs:NCName"/>
     </xs:complexType>
     <!-- Classifier definition -->
     <xs:complexType name="ClassifierType">
         <xs:attribute name="name" type="xs:NCName" use="required"/>
+        <xs:attribute name="scope" type="xs:NCName"/>
         <xs:attribute name="keys" type="xs:token" use="required"/>
     </xs:complexType>
     <!-- Attribute -->
     <xs:complexType name="AttributeType">
         <xs:complexContent>
             <xs:extension base="AttributableType">
-                <xs:attribute name="key" use="required" type="xs:Name"/>
+                <xs:attribute name="key" type="xs:Name" use="required"/>
             </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-    <!-- Elements may contain attributes -->
-    <xs:complexType name="ElementType">
-        <xs:complexContent>
-            <xs:extension base="AttributableType" />
         </xs:complexContent>
     </xs:complexType>
     <!-- Logs are elements that may contain traces -->
     <xs:complexType name="LogType">
-        <xs:complexContent>
-            <xs:extension base="ElementType">
-                <xs:sequence>
-                    <xs:element name="extension" minOccurs="0" maxOccurs="unbounded" type="ExtensionType" />
-                    <xs:element name="global" minOccurs="0" maxOccurs="2" type="GlobalsType"/>
-                    <xs:element name="classifier" minOccurs="0" maxOccurs="unbounded" type="ClassifierType" />
-                    <xs:element name="trace" minOccurs="0" maxOccurs="unbounded" type="TraceType" />
-                </xs:sequence>
-                <xs:attribute name="xes.version" type="xs:decimal" use="required"/>
-                <xs:attribute name="xes.features" type="xs:token"/>
-                <xs:attribute name="openxes.version" type="xs:string"/>
-            </xs:extension>
-        </xs:complexContent>
+        <xs:sequence>
+            <xs:element name="extension" type="ExtensionType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="global" type="GlobalsType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="classifier" type="ClassifierType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="AttributableGroup"/>
+            <xs:element name="trace" type="TraceType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="event" type="EventType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="xes.version" type="xs:decimal" use="required"/>
+        <xs:attribute name="xes.features" type="xs:token"/>
     </xs:complexType>
     <!-- Traces are elements that may contain events -->
     <xs:complexType name="TraceType">
-        <xs:complexContent>
-            <xs:extension base="ElementType">
-                <xs:sequence>
-                    <xs:element name="event" minOccurs="0" maxOccurs="unbounded" type="EventType" />
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
+        <xs:sequence>
+            <xs:group ref="AttributableGroup"/>
+            <xs:element name="event" type="EventType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
     </xs:complexType>
     <!-- Events are elements -->
     <xs:complexType name="EventType">
-        <xs:complexContent>
-            <xs:extension base="ElementType"></xs:extension>
-        </xs:complexContent>
+        <xs:group ref="AttributableGroup"/>
     </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
In diesem Pull Request wurde der Import und Export für XES angepasst, damit die exportierten XES-Dateien auch in ProM eingelesen werden können und weiterhin aus ProM exportierte in unsere Anwendung importiert werden können.

Ich habe dafür das repairExample leicht modifiziert sowie gekürzt und in Discord geteilt. Damit lässt es sich gut für unsere Anwendung testen. Wenn man die Datei importiert und ohne Änderung exportiert kommt die gleiche Datei wieder dabei heraus. Bei ProM für den Mac hatte ich leichte Schwierigkeiten dieses vernünftig zum Laufen zu bekommen. Da sich das Format jedoch nicht unterscheidet, gehe ich davon aus, dass sich dieses auch in ProM importieren lässt. Gerne einmal auf einem Windows System ansehen. Ich werde mir das nach meinem Urlaub auch noch genauer für den Mac ansehen.

Große Dateien lassen sich noch nicht importieren. Darum kümmert sich Eli in der Story EL-85.